### PR TITLE
Add support for new GPT5 models

### DIFF
--- a/src/news_briefing_generator/core/context.py
+++ b/src/news_briefing_generator/core/context.py
@@ -220,12 +220,15 @@ class ApplicationContext(AbstractAsyncContextManager):
                 "model": model,
                 "api_key": api_key,
                 "temperature": self.conf.get_param(
-                    "openai.temperature", default=0.4
+                    "openai.temperature", default=None
                 ).value,
                 "max_tokens": self.conf.get_param(
-                    "openai.max_tokens", default=12288
+                    "openai.max_tokens", default=None
                 ).value,
             }
+
+            # Remove None values to avoid passing them to the model
+            openai_params = {k: v for k, v in openai_params.items() if v is not None}
 
             self.default_llm = OpenAIModel(**openai_params)
             self.logger.info(f"Initialized OpenAI LLM: {str(self.default_llm)}")


### PR DESCRIPTION
Support handling of new OpenAI GPT5 models.

Fix previously seen error when using any of the GPT5 models: 
Error code: 400 - {'error': {'message': "Unsupported value: 'temperature' does not support 0.4 with this model. Only the default (1) value is supported.", 'type': 'invalid_request_error', 'param': 'temperature', 'code': 'unsupported_value'}

by passing only non-null args to the model.